### PR TITLE
Typed output of hash to ensure C compatibility

### DIFF
--- a/ProcessEntropy/Preprocessing.py
+++ b/ProcessEntropy/Preprocessing.py
@@ -33,7 +33,7 @@ def fnv(data):
     for byte in data:
         hval = (hval * 0x100000001b3) % 2**32
         hval = hval ^ byte
-    return hval
+    return np.uint32(hval)
 
 
 def custom_tokenize(text, basic_tokenize = False):
@@ -87,6 +87,7 @@ def tweet_to_hash_array(text):
             except UnicodeEncodeError:
                 continue # They're simply ignored
         return encoded
+
 
 
 


### PR DESCRIPTION
There were some issues when calculating with large ints when python wasn't typing them in a compatible way. This fixes it. The only change is explicitly typing the output of fnv.